### PR TITLE
Add the package cpgfR -  Consolidates Information from the Federal Government Payment Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Esse repositório traz uma lista de pacotes de R para acesso a dados brasileiros
 - [GetTDData](https://msperlin.github.io/GetTDData/): Get Data for Brazilian Bonds (Tesouro Direto)
 - [bndesr](https://CRAN.R-project.org/package=bndesr): Access Data from the Brazilian Development Bank (BNDES)
 - [BETS](https://CRAN.R-project.org/package=BETS): Brazilian Economic Time Series
-- [cpgfR](https://cran.r-project.org/web/packages/cpgfR/cpgfR.pdf): Consolidates Information from the Federal Government Payment Card
+- [cpgfR](https://CRAN.R-project.org/package=cpgfR): Consolidates Information from the Federal Government Payment Card
   
 ## Eleitorais e Política
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Esse repositório traz uma lista de pacotes de R para acesso a dados brasileiros
 - [GetTDData](https://msperlin.github.io/GetTDData/): Get Data for Brazilian Bonds (Tesouro Direto)
 - [bndesr](https://CRAN.R-project.org/package=bndesr): Access Data from the Brazilian Development Bank (BNDES)
 - [BETS](https://CRAN.R-project.org/package=BETS): Brazilian Economic Time Series
-- [cpgf](https://cran.r-project.org/web/packages/cpgfR/cpgfR.pdf): Consolidates Information from the Federal Government Payment Card
+- [cpgfR](https://cran.r-project.org/web/packages/cpgfR/cpgfR.pdf): Consolidates Information from the Federal Government Payment Card
   
 ## Eleitorais e Política
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Esse repositório traz uma lista de pacotes de R para acesso a dados brasileiros
 - [GetTDData](https://msperlin.github.io/GetTDData/): Get Data for Brazilian Bonds (Tesouro Direto)
 - [bndesr](https://CRAN.R-project.org/package=bndesr): Access Data from the Brazilian Development Bank (BNDES)
 - [BETS](https://CRAN.R-project.org/package=BETS): Brazilian Economic Time Series
+- [cpgf](https://cran.r-project.org/web/packages/cpgfR/cpgfR.pdf): Consolidates Information from the Federal Government Payment Card
   
 ## Eleitorais e Política
 


### PR DESCRIPTION
Add the package [cpgfR](https://cran.r-project.org/web/packages/cpgfR/cpgfR.pdf)

Title: Consolidates Information from the Federal Government Payment Card

Description: Provides access to consolidated information from the Brazilian Federal Government Pay-
ment Card. Includes functions to retrieve, clean, and organize data directly from the Trans-
parency Portal <https://portaldatransparencia.gov.br/download-de-dados/cpgf/> and a cu-
rated dataset hosted on the Open Science Framework <https://osf.io/z2mxc/>.
Useful for public spending analysis, transparency research, and reproducible workflows in audit-
ing or investigative journalism