### PR TITLE
Add datazoom.social package to brverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Esse repositório traz uma lista de pacotes de R para acesso a dados brasileiros
 - [brpop](https://rfsaldanha.github.io/brpop/): Brazilian Population Estimates
 - [PNADcIBGE](https://CRAN.R-project.org/package=PNADcIBGE): Downloading, Reading and Analyzing PNADC Microdata
 - [PNADCperiods](https://CRAN.R-project.org/package=PNADCperiods): Identify Reference Periods in Brazil's PNADC Survey Data
+- [datazoom.social](https://CRAN.R-project.org/package=datazoom.social): Download microdata from the PNADC and includes panel identification algorithms for linking individuals across survey waves.
 
 ## Saúde
 


### PR DESCRIPTION
Adds [datazoom.social](https://cran.r-project.org/package=datazoom.social) to the População e dados socioeconômicos section. The package provides tools for downloading and processing microdata from the PNAD Contínua (PNADC), including panel identification algorithms for linking individuals across survey waves. It is also avaiable on CRAN, meeting all of the proposed standards.